### PR TITLE
Rework BUILDTAG to follow Contrail build naming convention.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,6 @@
-SRC_VER := $(shell cat ./../controller/src/base/version.info)
-BUILDTIME := $(shell date -u +%m%d%Y)
-
-ifdef SRC_VER
-BUILDTAG = $(SRC_VER)-$(BUILDTIME)
-else
-BUILDTAG = $(BUILDTIME)
-endif
-
+SRC_VER ?= $(shell cat ./../controller/src/base/version.info)
+BUILDNUM ?= $(shell date -u +%m%d%Y)
+export BUILDTAG ?= $(SRC_VER)-$(BUILDNUM)
 
 all:
 	$(eval BUILDDIR=./../build/java-api)
@@ -17,7 +11,7 @@ all:
 	(cd ${BUILDDIR}; mvn install)
 	#(cd ${BUILDDIR}; fakeroot debian/rules clean)
 	#(cd ${BUILDDIR}; fakeroot debian/rules binary)
-	(cd ${BUILDDIR}; debuild -i -us -uc -b)
+	(cd ${BUILDDIR}; debuild --preserve-envvar=BUILDTAG -i -us -uc -b)
 	@echo "Wrote: ${BUILDDIR}/../libcontrail-java-api_${BUILDTAG}_all.deb"
 
 clean:

--- a/debian/rules
+++ b/debian/rules
@@ -4,14 +4,9 @@
 export INSTALL_ROOT=$(shell pwd)
 JAVA_HOME=/usr/lib/jvm/default-java
 
-SRC_VER := $(shell cat ./../../controller/src/base/version.info)
-BUILDDATE := $(shell date -u +%m%d%Y)
-
-ifdef SRC_VER
-BUILDTAG = $(SRC_VER)-$(BUILDDATE)
-else
-BUILDTAG = $(BUILDDATE)
-endif
+SRC_VER ?= $(shell cat ./../controller/src/base/version.info)
+BUILDNUM ?= $(shell date -u +%m%d%Y)
+export BUILDTAG ?= $(SRC_VER)-$(BUILDNUM)
 
 %:
 	dh $@ --with javahelper


### PR DESCRIPTION
This will make EC build version string work.
