### PR TITLE
add keystone authenticate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.pacesys</groupId>
+      <artifactId>openstack4j</artifactId>
+      <version>2.0.1</version>
+      <classifier>withdeps</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>15.0</version>

--- a/src/net/juniper/contrail/api/ApiConnector.java
+++ b/src/net/juniper/contrail/api/ApiConnector.java
@@ -8,6 +8,11 @@ import java.io.IOException;
 import java.util.List;
 
 public interface ApiConnector {
+    ApiConnector credentials(String username, String password);
+    ApiConnector tenantName(String tenantName);
+    ApiConnector authToken(String token);
+    ApiConnector authServer(String type, String url);
+
     boolean create(ApiObjectBase obj) throws IOException;
     boolean read(ApiObjectBase obj) throws IOException;
     boolean update(ApiObjectBase obj) throws IOException;

--- a/src/net/juniper/contrail/api/ApiConnectorImpl.java
+++ b/src/net/juniper/contrail/api/ApiConnectorImpl.java
@@ -46,6 +46,10 @@ import org.apache.http.protocol.RequestUserAgent;
 import org.apache.http.util.EntityUtils;
 import org.apache.log4j.Logger;
 
+import org.openstack4j.api.OSClient;
+import org.openstack4j.openstack.OSFactory;
+import org.openstack4j.api.exceptions.AuthenticationException;
+
 import com.google.common.collect.ImmutableList;
 
 class ApiConnectorImpl implements ApiConnector {
@@ -55,6 +59,14 @@ class ApiConnectorImpl implements ApiConnector {
     private String _api_hostname;
     private int _api_port;
     private ApiBuilder _apiBuilder;
+
+    private String _username;
+    private String _password;
+    private String _tenant;
+    private boolean _has_input_authtoken;
+    private String _authtoken;
+    private String _authtype;
+    private String _authurl;
 
     // HTTP Connection parameters
     private HttpParams _params;
@@ -68,6 +80,7 @@ class ApiConnectorImpl implements ApiConnector {
     public ApiConnectorImpl(String hostname, int port) {
         _api_hostname = hostname;
         _api_port = port;
+        _has_input_authtoken = true;
         initHttpClient();
         initHttpServerParams(hostname, port); 
         _apiBuilder = new ApiBuilder();
@@ -113,6 +126,31 @@ class ApiConnectorImpl implements ApiConnector {
         return;
     }
 
+    @Override
+    public ApiConnector credentials(String username, String password) {
+        _username = username;
+        _password = password;
+        return this;
+    }
+    @Override
+    public ApiConnector tenantName(String tenant) {
+        _tenant = tenant;
+        return this;
+    }
+    @Override
+    public ApiConnector authToken(String token) {
+        _has_input_authtoken = true;
+        _authtoken = token;
+        return this;
+    }
+    @Override
+    public ApiConnector authServer(String type, String url) {
+        _has_input_authtoken = false;
+        _authtype = type;
+        _authurl = url;
+        return this;
+    }
+
     private void checkResponseKeepAliveStatus(HttpResponse response) throws IOException {
 
         if (!_connectionStrategy.keepAlive(response, _httpcontext)) {
@@ -151,7 +189,36 @@ class ApiConnectorImpl implements ApiConnector {
         return  _api_port;
     }
 
+    // return value indicates whether the token changed
+    private boolean authenticate() {
+        if (_has_input_authtoken) {
+            return false;
+        }
+
+        _authtoken = null;
+        if (_authtype == "keystone") {
+            try {
+                OSClient os = OSFactory.builder().endpoint(_authurl)
+                    .credentials(_username, _password).tenantName(_tenant).authenticate();
+                _authtoken = os.getToken().getId();
+                return true;
+            }
+            catch (AuthenticationException authe) {
+                s_logger.warn("authenticate to keystone " + _authurl + "failed: " + authe);
+                return false;
+            }
+        }
+
+        // authenticate type unknown
+        return false;
+    }
+
     public HttpResponse execute(String method, String uri, StringEntity entity) throws IOException {
+        return execute_doauth(method, uri, entity, false);
+    }
+
+    private HttpResponse execute_doauth(String method, String uri, StringEntity entity,
+                boolean retry_after_authn) throws IOException {
 
         checkConnection();
 
@@ -165,6 +232,9 @@ class ApiConnectorImpl implements ApiConnector {
         }
         HttpResponse response  = null;
         request.setParams(_params);
+        if (_authtoken != null) {
+            request.setHeader("X-AUTH-TOKEN", _authtoken);
+        }
         try {
             _httpexecutor.preProcess(request, _httpproc, _httpcontext);
             response = _httpexecutor.execute(request, _connection, _httpcontext);
@@ -173,8 +243,17 @@ class ApiConnectorImpl implements ApiConnector {
         } catch (Exception e) {
             e.printStackTrace();
         }
-
         s_logger.info("<< Response Status: " + response.getStatusLine());
+
+        if (response.getStatusLine().getStatusCode() == HttpStatus.SC_UNAUTHORIZED
+                && !retry_after_authn) {
+            if (authenticate()) {
+                getResponseData(response);
+                checkResponseKeepAliveStatus(response);
+                return execute_doauth(method, uri, entity, true);
+            }
+        }
+
         return response;
     }
 


### PR DESCRIPTION
Add authenticate support to java api. Keystone token is requested using openstack4j library.
usage:

``` java
_api = ApiConnectorFactory.build("192.168.1.150", 8082)
                .credentials("admin", "admin").tenantName("admin")
                .authServer("keystone", "http://192.168.1.150:5000/v2.0");
```

It would be better to register contrail api service to keystone, and Integrate ApiConnectorFactory with openstack4j's OSFactory:

```
OSClient os = OSFactory.builder()
                       .endpoint("http://127.0.0.1:5000/v2.0")
                       .credentials("admin","sample")
                       .tenantName("admin")
                       .authenticate();
_api = os.VncApi()
```
