### PR TITLE
Fix string comparison in ApiConnectorImpl

### DIFF
--- a/src/net/juniper/contrail/api/ApiConnectorImpl.java
+++ b/src/net/juniper/contrail/api/ApiConnectorImpl.java
@@ -196,7 +196,7 @@ class ApiConnectorImpl implements ApiConnector {
         }
 
         _authtoken = null;
-        if (_authtype == "keystone") {
+        if ("keystone".equals(_authtype)) {
             try {
                 OSClient os = OSFactory.builder().endpoint(_authurl)
                     .credentials(_username, _password).tenantName(_tenant).authenticate();


### PR DESCRIPTION
`_authtype == "keystone"` should be replaced with `"keystone".equals(_authtype)`