### PR TITLE
Allow for manual closing of API connections.

### DIFF
--- a/src/net/juniper/contrail/api/ApiConnector.java
+++ b/src/net/juniper/contrail/api/ApiConnector.java
@@ -45,4 +45,6 @@ public interface ApiConnector {
             List<ObjectReference<T>> refList) throws IOException;
 
     public boolean sync(String uri) throws IOException;
+
+    public void dispose();
 }

--- a/src/net/juniper/contrail/api/ApiConnectorImpl.java
+++ b/src/net/juniper/contrail/api/ApiConnectorImpl.java
@@ -178,14 +178,9 @@ class ApiConnectorImpl implements ApiConnector {
         return;
     }
 
-    protected void finalize() throws Throwable {
-        try {
-            if (_connection.isOpen()) {
-                _connection.close();        // close server connection
-            }
-        } finally {
-            super.finalize();
-        }
+    @Override
+    protected void finalize() {
+        dispose();
     }
 
 
@@ -652,5 +647,16 @@ class ApiConnectorImpl implements ApiConnector {
         }
 
         return true;
+    }
+
+    @Override
+    public void dispose() {
+        try {
+            if (_connection.isOpen()) {
+                _connection.close();        // close server connection
+            }
+        } catch (IOException ex) {
+            s_logger.warn("Exception while closing server connection: " + ex.getMessage());
+        }
     }
 }

--- a/src/net/juniper/contrail/api/ApiConnectorMock.java
+++ b/src/net/juniper/contrail/api/ApiConnectorMock.java
@@ -712,5 +712,9 @@ public class ApiConnectorMock implements ApiConnector {
     public boolean sync(String uri) throws IOException {
         return true;
     }
+
+    @Override
+    public void dispose() {
+    }
 }
 


### PR DESCRIPTION
Closing connection should not be done in finalize method, because finalization might never be performed if the system has enough memory.